### PR TITLE
Add SSH backup option and update README with PowerShell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@
 > [!WARNING]
 > Execute sempre com o botão direito → **"Executar como administrador"**
 
+<div align="center">
+
+### **Ou execute diretamente via PowerShell(Administrador):**
+
+```powershell
+irm https://raw.githubusercontent.com/winchestercanal/WINbackup-Script/refs/heads/main/WINbackup.bat -OutFile WINbackup.bat && cmd /c WINbackup.bat
+```
+</div>
+
 ---
 
 ## 🚀 Como Usar

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Faz o backup das suas pastas pessoais para qualquer destino — HD externo, pend
 | 4 | 🎬 Vídeos |
 | 5 | ⬇️ Downloads |
 | 6 | 🖥️ Desktop |
+| 7 | 🔑 SSH |
 
 ### ⚙️ Modos de backup
 
@@ -87,7 +88,7 @@ Faz o backup das suas pastas pessoais para qualquer destino — HD externo, pend
 
 **`C` — Backup Completo**
 
-Copia todas as 6 pastas de uma vez.
+Copia todas as 7 pastas de uma vez.
 
 </td>
 <td width="50%">

--- a/WINbackup.bat
+++ b/WINbackup.bat
@@ -76,6 +76,7 @@ set /p modoArq=  Digite sua opcao (C, S ou 0):
 if /i "!modoArq!"=="c" (
     set "bDoc=1" & set "bImg=1" & set "bMus=1"
     set "bVid=1" & set "bDwn=1" & set "bDsk=1"
+    set "bSsh=1"
     goto pedirDestinoArquivos
 )
 if /i "!modoArq!"=="s" goto selecionarPastas
@@ -107,6 +108,7 @@ set /p sel=  Sua selecao:
 
 set "bDoc=0" & set "bImg=0" & set "bMus=0"
 set "bVid=0" & set "bDwn=0" & set "bDsk=0"
+set "bSsh=0"
 
 echo !sel! | find "1" >nul 2>&1 && set "bDoc=1"
 echo !sel! | find "2" >nul 2>&1 && set "bImg=1"


### PR DESCRIPTION
This pull request updates the `WINbackup` script and its documentation to add support for backing up the SSH folder, and improves the instructions for running the script as an administrator. The main changes are grouped below.

**Feature: SSH folder backup support**
* Added the SSH folder as a backup option in both the script (`WINbackup.bat`) and the documentation, including updating the list of folders and the description of the complete backup mode. [[1]](diffhunk://#diff-74ed4c78ada64d17a8880c68209081d8357101a558d98a6e259d3c06950cbf17R79) [[2]](diffhunk://#diff-74ed4c78ada64d17a8880c68209081d8357101a558d98a6e259d3c06950cbf17R111) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R91)

**Documentation: Improved usage instructions**
* Added a PowerShell command snippet to the `README.md` for running the script directly as administrator, making it easier for users to execute the backup script.